### PR TITLE
Fix unreachable line in recipe generator

### DIFF
--- a/recipe_generator.py
+++ b/recipe_generator.py
@@ -140,4 +140,3 @@ def generate_recipes(sheet_id, service_account_info, folder_id, brand_code, bran
         body={"values": output}
     ).execute()
     return output
-    recipes.append(recipe)


### PR DESCRIPTION
## Summary
- remove stray code after return in `recipe_generator`

## Testing
- `python -m py_compile main_tagger.py chat_classifier.py recipe_generator.py tagger_app.py`
