### PR TITLE
Add optional content tagging support

### DIFF
--- a/chat_classifier.py
+++ b/chat_classifier.py
@@ -5,7 +5,29 @@ import json
 
 client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
-def chat_classify(labels, web_labels, expected_audiences, expected_products, expected_angles) -> dict:
+def chat_classify(
+    labels,
+    web_labels,
+    expected_audiences,
+    expected_products,
+    expected_angles,
+    expected_content=None,
+) -> dict:
+    """Classify image tags using ChatGPT.
+
+    Parameters
+    ----------
+    labels : list[str]
+        Generic labels returned from Vision API.
+    web_labels : list[str]
+        Web entity labels returned from Vision API.
+    expected_audiences, expected_products, expected_angles : list[str]
+        Category lists for matching.
+    expected_content : list[str] | None, optional
+        Additional content tags to consider. Defaults to ``[]``.
+    """
+
+    expected_content = expected_content or []
     prompt = f"""
 You are an ad tagging assistant. Based on the following image data:
 
@@ -27,6 +49,7 @@ If there's no good match, return "unknown".
 Expected audiences: {', '.join(expected_audiences)}
 Expected products: {', '.join(expected_products)}
 Expected angles: {', '.join(expected_angles)}
+Expected content tags: {', '.join(expected_content)}
 
 Return:
 {{
@@ -50,7 +73,10 @@ Return:
             temperature=0.4,
         )
         content = response.choices[0].message.content
-        return json.loads(content)
+        data = json.loads(content)
+        # Older prompts may omit the optional match_content field
+        data.setdefault("match_content", "unknown")
+        return data
     except Exception as e:
         print("ChatGPT classification error:", e)
         return {
@@ -60,5 +86,6 @@ Return:
             "descriptors": [],
             "match_audience": "unknown",
             "match_product": "unknown",
-            "match_angle": "unknown"
+            "match_angle": "unknown",
+            "match_content": "unknown",
         }

--- a/main_tagger.py
+++ b/main_tagger.py
@@ -64,8 +64,32 @@ def write_to_sheet(sheet_id, rows):
         body={'values': rows}
     ).execute()
 
-def run_tagger(sheet_id, folder_id, expected_audiences, expected_products, expected_angles):
-    rows = [['Image Name', 'Image Link', 'Google Labels', 'Google Web Entities', 'GPT Audience', 'GPT Product', 'GPT Angle', 'Descriptors', 'Matched Audience', 'Matched Product', 'Matched Angle']]
+def run_tagger(sheet_id, folder_id, expected_audiences, expected_products, expected_angles, expected_content=None):
+    """Tag images in a Drive folder and write results to a Google Sheet.
+
+    Parameters
+    ----------
+    sheet_id : str
+        Destination Google Sheet ID.
+    folder_id : str
+        Source Drive folder containing images.
+    expected_audiences : list[str]
+        Possible audience tags.
+    expected_products : list[str]
+        Possible product tags.
+    expected_angles : list[str]
+        Possible angle tags.
+    expected_content : list[str] | None, optional
+        Additional content tags to classify. Defaults to ``[]`` if not
+        provided.
+    """
+
+    expected_content = expected_content or []
+
+    rows = [['Image Name', 'Image Link', 'Google Labels', 'Google Web Entities',
+             'GPT Audience', 'GPT Product', 'GPT Angle', 'Descriptors',
+             'Matched Audience', 'Matched Product', 'Matched Angle',
+             'Matched Content']]
     files = list_images(folder_id)
     for file in files:
         labels, web_labels = analyze_image(file['id'])
@@ -75,7 +99,8 @@ def run_tagger(sheet_id, folder_id, expected_audiences, expected_products, expec
             web_labels,
             expected_audiences,
             expected_products,
-            expected_angles
+            expected_angles,
+            expected_content,
         )
 
         gpt_audience = chat_result.get("audience", "unknown")
@@ -85,6 +110,7 @@ def run_tagger(sheet_id, folder_id, expected_audiences, expected_products, expec
         matched_audience = chat_result.get("match_audience", "unknown")
         matched_product = chat_result.get("match_product", "unknown")
         matched_angle = chat_result.get("match_angle", "unknown")
+        matched_content = chat_result.get("match_content", "unknown")
 
         rows.append([
             file['name'],
@@ -97,6 +123,7 @@ def run_tagger(sheet_id, folder_id, expected_audiences, expected_products, expec
             descriptors,
             matched_audience,
             matched_product,
-            matched_angle
+            matched_angle,
+            matched_content,
         ])
     write_to_sheet(sheet_id, rows)


### PR DESCRIPTION
## Summary
- extend `run_tagger` to optionally handle expected content tags
- update ChatGPT classifier to accept `expected_content`
- include expected content tags in prompts and keep reading `match_content`

## Testing
- `python -m py_compile main_tagger.py chat_classifier.py`
- ❌ `pytest -q` *(fails: `pytest` not installed and cannot fetch package)*