### PR TITLE
Remove unused streamlit import

### DIFF
--- a/main_tagger.py
+++ b/main_tagger.py
@@ -2,7 +2,6 @@
 import io
 import json
 import toml
-import streamlit as st
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload


### PR DESCRIPTION
## Summary
- clean up unused import from `main_tagger.py`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*