### PR TITLE
Fix tagger parsing of Vision results

### DIFF
--- a/chat_classifier.py
+++ b/chat_classifier.py
@@ -55,10 +55,14 @@ Return:
         response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
-                {"role": "system", "content": "You are a helpful and structured tag classification assistant."},
-                {"role": "user", "content": prompt.strip()}
+                {
+                    "role": "system",
+                    "content": "You are a helpful and structured tag classification assistant.",
+                },
+                {"role": "user", "content": prompt.strip()},
             ],
             temperature=0.4,
+            response_format={"type": "json_object"},
         )
         content = response.choices[0].message.content
         data = json.loads(content)

--- a/main_tagger.py
+++ b/main_tagger.py
@@ -80,8 +80,10 @@ def analyze_image(file_id):
         ]
     })
 
-    labels = [label.description for label in response.label_annotations]
-    web_labels = [entity.description for entity in response.web_detection.web_entities]
+    labels = [label.description for label in getattr(response, 'label_annotations', [])]
+    web_detection = getattr(response, 'web_detection', None)
+    entities = getattr(web_detection, 'web_entities', []) if web_detection else []
+    web_labels = [entity.description for entity in entities]
 
     return labels, web_labels
 


### PR DESCRIPTION
## Summary
- handle missing annotations in Vision API response
- ensure chat classifier always returns parseable JSON

## Testing
- `python -m py_compile chat_classifier.py main_tagger.py`