### PR TITLE
Add audience/product/angle tagging

### DIFF
--- a/main_tagger.py
+++ b/main_tagger.py
@@ -125,8 +125,17 @@ def run_tagger(sheet_id, folder_id, expected_content=None):
 
     expected_content = expected_content or []
 
-    rows = [['Image Name', 'Image Link', 'Google Labels', 'Google Web Entities',
-             'Descriptors', 'Matched Content']]
+    rows = [[
+        'Image Name',
+        'Image Link',
+        'Google Labels',
+        'Google Web Entities',
+        'Descriptors',
+        'Matched Content',
+        'Audience',
+        'Product',
+        'Angle',
+    ]]
     files = list_images(folder_id)
     for file in files:
         labels, web_labels = analyze_image(file['id'])
@@ -139,6 +148,9 @@ def run_tagger(sheet_id, folder_id, expected_content=None):
 
         descriptors = ', '.join(chat_result.get("descriptors", []))
         matched_content = chat_result.get("match_content", "unknown")
+        audience = chat_result.get("audience", "unknown")
+        product = chat_result.get("product", "unknown")
+        angle = chat_result.get("angle", "unknown")
 
         rows.append([
             file['name'],
@@ -147,5 +159,8 @@ def run_tagger(sheet_id, folder_id, expected_content=None):
             ', '.join(web_labels),
             descriptors,
             matched_content,
+            audience,
+            product,
+            angle,
         ])
     write_to_sheet(sheet_id, rows)

--- a/tests/test_main_tagger.py
+++ b/tests/test_main_tagger.py
@@ -78,9 +78,39 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
     monkeypatch.setattr(main_tagger, 'write_to_sheet', fake_write)
     monkeypatch.setattr(main_tagger, 'list_images', lambda fid: [{'id': '1', 'name': 'img', 'webViewLink': 'link'}])
     monkeypatch.setattr(main_tagger, 'analyze_image', lambda fid: (['label'], ['web']))
-    monkeypatch.setattr(main_tagger, 'chat_classify', lambda *a, **k: {'descriptors': ['desc'], 'match_content': 'match'})
+    monkeypatch.setattr(
+        main_tagger,
+        'chat_classify',
+        lambda *a, **k: {
+            'descriptors': ['desc'],
+            'match_content': 'match',
+            'audience': 'aud',
+            'product': 'prod',
+            'angle': 'ang',
+        },
+    )
 
     main_tagger.run_tagger('sid', 'fid', ['x'])
 
-    assert captured['rows'][0] == ['Image Name', 'Image Link', 'Google Labels', 'Google Web Entities', 'Descriptors', 'Matched Content']
-    assert captured['rows'][1] == ['img', 'link', 'label', 'web', 'desc', 'match']
+    assert captured['rows'][0] == [
+        'Image Name',
+        'Image Link',
+        'Google Labels',
+        'Google Web Entities',
+        'Descriptors',
+        'Matched Content',
+        'Audience',
+        'Product',
+        'Angle',
+    ]
+    assert captured['rows'][1] == [
+        'img',
+        'link',
+        'label',
+        'web',
+        'desc',
+        'match',
+        'aud',
+        'prod',
+        'ang',
+    ]


### PR DESCRIPTION
## Summary
- update `run_tagger` to include audience, product and angle columns
- update corresponding test expectations

## Testing
- `python -m py_compile main_tagger.py tests/test_main_tagger.py`
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*