### PR TITLE
Ensure recipes sheet exists before update

### DIFF
--- a/recipe_generator.py
+++ b/recipe_generator.py
@@ -191,6 +191,17 @@ def generate_recipes(
             ""
         ])
 
+    # Ensure the destination sheet exists before writing
+    metadata = sheets_service.spreadsheets().get(
+        spreadsheetId=sheet_id
+    ).execute()
+    sheet_titles = [s.get("properties", {}).get("title") for s in metadata.get("sheets", [])]
+    if "recipes" not in sheet_titles:
+        sheets_service.spreadsheets().batchUpdate(
+            spreadsheetId=sheet_id,
+            body={"requests": [{"addSheet": {"properties": {"title": "recipes"}}}]},
+        ).execute()
+
     # Write output to Google Sheet
     sheets_service.spreadsheets().values().update(
         spreadsheetId=sheet_id,

--- a/tests/test_recipe_generator.py
+++ b/tests/test_recipe_generator.py
@@ -164,6 +164,16 @@ def test_generate_recipes_filters_layouts_and_copy(monkeypatch):
     class FakeSpreadsheets:
         def values(self):
             return FakeValues()
+        def get(self, spreadsheetId):
+            class FakeGet:
+                def execute(self_inner):
+                    return {"sheets": [{"properties": {"title": "recipes"}}]}
+            return FakeGet()
+        def batchUpdate(self, **kwargs):
+            class FakeBatch:
+                def execute(self_inner):
+                    pass
+            return FakeBatch()
     class FakeSheetsService:
         def spreadsheets(self):
             return FakeSpreadsheets()


### PR DESCRIPTION
## Summary
- create recipes sheet when missing before updating values
- add stubbed sheet methods in tests

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*