### PR TITLE
Add URL parsing and saved sheet/folder history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ secrets.toml
 __pycache__/
 *.pyc
 .DS_Store
+.tak_history.json

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Run the interactive tagging and recipe builder UI:
 streamlit run tagger_app.py
 ```
 
+You can paste entire Google Sheet or Drive URLs into the form fields. The app
+stores sheet and folder names you use in `.tak_history.json` and provides them
+in dropdown menus for quick reuse.
+
 ### CLI Example
 
 You can call the utility functions from the command line. For example, to tag images:

--- a/tagger_app.py
+++ b/tagger_app.py
@@ -2,11 +2,13 @@
 import streamlit as st
 import toml
 import json
+import os
 from streamlit_tags import st_tags
 from main_tagger import run_tagger
 from recipe_generator import generate_recipes, read_sheet, LAYOUT_COPY_SHEET_ID
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from utils import parse_google_id, load_history, save_history
 
 # Load app secrets
 with open("secrets.toml", "r") as f:
@@ -14,6 +16,7 @@ with open("secrets.toml", "r") as f:
 
 app_password = secrets["app_password"]
 SERVICE_ACCOUNT_INFO = json.loads(secrets["google"]["service_account"])
+HISTORY = load_history()
 
 def get_google_service(service_account_info):
     """Create authorized Google Sheets and Drive clients.
@@ -37,6 +40,14 @@ def get_google_service(service_account_info):
     )
     return build('sheets', 'v4', credentials=credentials), build('drive', 'v3', credentials=credentials)
 
+def get_file_name(drive_service, file_id):
+    """Return Drive file name for given ID."""
+    try:
+        meta = drive_service.files().get(fileId=file_id, fields='name').execute()
+        return meta.get('name', file_id)
+    except Exception:
+        return file_id
+
 @st.cache_data(show_spinner=False)
 def load_layout_copy_options(service_account_info):
     """Fetch layout and copy format options and cache the result."""
@@ -57,8 +68,25 @@ if password != app_password:
 tab1, tab2, tab_brand = st.tabs(["🧠 Tag Assets", "📋 Generate Recipes", "🏷 Manage Brands"])
 with tab1:
     st.title("🧠 Tag Image Assets")
-    sheet_id = st.text_input("Google Sheet ID (for tagged assets)", key="tag_sheet")
-    folder_id = st.text_input("Google Drive Folder ID (image folder)")
+    sheet_options = {e['name']: e['id'] for e in HISTORY.get('sheets', [])}
+    folder_options = {e['name']: e['id'] for e in HISTORY.get('folders', [])}
+
+    selected_sheet = st.selectbox(
+        "Saved Sheets",
+        options=[""] + list(sheet_options.keys()),
+        key="tag_saved_sheet",
+    )
+    sheet_input = st.text_input(
+        "Google Sheet URL or ID (for tagged assets)", key="tag_sheet"
+    )
+    selected_folder = st.selectbox(
+        "Saved Folders",
+        options=[""] + list(folder_options.keys()),
+        key="tag_saved_folder",
+    )
+    folder_input = st.text_input(
+        "Google Drive Folder URL or ID (image folder)", key="tag_folder"
+    )
 
     st.subheader("Expected Content")
     expected_content = st_tags(label="Add tags", key="expected_content")
@@ -66,17 +94,46 @@ with tab1:
     if st.button("Run Tagging"):
         try:
             st.info("Tagging images...")
-            run_tagger(sheet_id, folder_id, expected_content)
+            final_sheet = sheet_options.get(selected_sheet) or parse_google_id(sheet_input)
+            final_folder = folder_options.get(selected_folder) or parse_google_id(folder_input)
+            run_tagger(final_sheet, final_folder, expected_content)
+
+            sheets_service, drive_service = get_google_service(SERVICE_ACCOUNT_INFO)
+            if not any(e['id'] == final_sheet for e in HISTORY.get('sheets', [])):
+                HISTORY.setdefault('sheets', []).append({
+                    'id': final_sheet,
+                    'name': get_file_name(drive_service, final_sheet)
+                })
+            if not any(e['id'] == final_folder for e in HISTORY.get('folders', [])):
+                HISTORY.setdefault('folders', []).append({
+                    'id': final_folder,
+                    'name': get_file_name(drive_service, final_folder)
+                })
+            save_history(HISTORY)
             st.success("✅ Tagging complete. Check your Google Sheet.")
         except Exception as e:
             st.error(f"❌ Error: {e}")
 
 with tab2:
     st.title("📋 Generate Creative Recipes")
-    col_main, = st.columns([1]) 
+    col_main, = st.columns([1])
     with col_main:
-        recipe_sheet_id = st.text_input("Tagged Asset Sheet ID", key="recipe_sheet")
-        image_folder_id = st.text_input("Google Drive Folder ID (for image links)", key="asset_folder")
+        recipe_sheet_select = st.selectbox(
+            "Saved Sheets",
+            options=[""] + list(sheet_options.keys()),
+            key="recipe_saved_sheet",
+        )
+        recipe_sheet_id_input = st.text_input(
+            "Tagged Asset Sheet URL or ID", key="recipe_sheet"
+        )
+        image_folder_select = st.selectbox(
+            "Saved Folders",
+            options=[""] + list(folder_options.keys()),
+            key="recipe_saved_folder",
+        )
+        image_folder_id_input = st.text_input(
+            "Google Drive Folder URL or ID (for image links)", key="asset_folder"
+        )
         brand_code = st.text_input("Brand Code (matches brand list)", key="brand_code")
 
         try:
@@ -98,10 +155,12 @@ with tab2:
         if st.button("Generate Recipes"):
             try:
                 st.info("Generating recipes...")
+                final_sheet = sheet_options.get(recipe_sheet_select) or parse_google_id(recipe_sheet_id_input)
+                final_folder = folder_options.get(image_folder_select) or parse_google_id(image_folder_id_input)
                 recipes = generate_recipes(
-                    recipe_sheet_id,
+                    final_sheet,
                     SERVICE_ACCOUNT_INFO,
-                    image_folder_id,
+                    final_folder,
                     brand_code,
                     BRAND_SHEET_ID,
                     num_recipes,
@@ -111,6 +170,18 @@ with tab2:
                     selected_layouts=selected_layouts,
                     selected_copy_formats=selected_copy_formats,
                 )
+                sheets_service, drive_service = get_google_service(SERVICE_ACCOUNT_INFO)
+                if not any(e['id'] == final_sheet for e in HISTORY.get('sheets', [])):
+                    HISTORY.setdefault('sheets', []).append({
+                        'id': final_sheet,
+                        'name': get_file_name(drive_service, final_sheet)
+                    })
+                if not any(e['id'] == final_folder for e in HISTORY.get('folders', [])):
+                    HISTORY.setdefault('folders', []).append({
+                        'id': final_folder,
+                        'name': get_file_name(drive_service, final_folder)
+                    })
+                save_history(HISTORY)
                 st.success("✅ Recipes generated. Check your Google Sheet.")
             except Exception as e:
                 st.error(f"❌ Error: {e}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+from utils import parse_google_id
+
+def test_parse_google_id():
+    sheet_url = 'https://docs.google.com/spreadsheets/d/ABC123/edit'
+    folder_url = 'https://drive.google.com/drive/folders/FOLDER456'
+    assert parse_google_id(sheet_url) == 'ABC123'
+    assert parse_google_id(folder_url) == 'FOLDER456'
+    assert parse_google_id('PLAINID') == 'PLAINID'

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,38 @@
+import json
+import os
+import re
+
+HISTORY_FILE = '.tak_history.json'
+
+def parse_google_id(value: str) -> str:
+    """Return the Google ID found in a full URL or raw ID string."""
+    if not value:
+        return ''
+    value = value.strip()
+    if 'http' not in value:
+        return value
+    patterns = [
+        r'/d/([A-Za-z0-9_-]+)',
+        r'/folders/([A-Za-z0-9_-]+)',
+        r'id=([A-Za-z0-9_-]+)'
+    ]
+    for pat in patterns:
+        match = re.search(pat, value)
+        if match:
+            return match.group(1)
+    return value
+
+def load_history(path: str = HISTORY_FILE) -> dict:
+    """Load saved sheet and folder references."""
+    if os.path.exists(path):
+        try:
+            with open(path, 'r') as f:
+                return json.load(f)
+        except Exception:
+            return {'sheets': [], 'folders': []}
+    return {'sheets': [], 'folders': []}
+
+def save_history(history: dict, path: str = HISTORY_FILE) -> None:
+    """Persist history data to disk."""
+    with open(path, 'w') as f:
+        json.dump(history, f)


### PR DESCRIPTION
## Summary
- parse IDs from Google URLs in new `utils.py`
- store previously used sheet and folder IDs in `.tak_history.json`
- update Streamlit UI to select saved locations or paste new URLs
- document the feature in README
- ignore history file and add small utility test

## Testing
- `python -m py_compile utils.py tagger_app.py main_tagger.py recipe_generator.py`