### PR TITLE
Update README on history file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ Run the interactive tagging and recipe builder UI:
 streamlit run tagger_app.py
 ```
 
-You can paste entire Google Sheet or Drive URLs into the form fields. The app
-stores sheet and folder names you use in `.tak_history.json` and provides them
-in dropdown menus for quick reuse.
+You can paste entire Google Sheet or Drive URLs into the form fields. The
+Streamlit app writes previously used sheet and folder names to
+`.tak_history.json` located in the project root and provides them in dropdown
+menus for quick reuse. Edit or delete this file if you need to clear your
+history.
 
 ### CLI Example
 


### PR DESCRIPTION
## Summary
- document where `.tak_history.json` lives
- explain how to clear history from Streamlit dropdowns

## Testing
- `pytest -q` *(fails: pytest not installed)*