### PR TITLE
Fix missing sheet input on recipe tab

### DIFF
--- a/tagger_app.py
+++ b/tagger_app.py
@@ -151,6 +151,11 @@ with tab2:
     st.title("📋 Generate Creative Recipes")
     col_main, = st.columns([1])
     with col_main:
+        recipe_sheet_id = history_input(
+            "Google Sheet URL or ID (for tagged assets)",
+            sheet_options,
+            "recipe_sheet",
+        )
         image_folder_id = history_input(
             "Google Drive Folder URL or ID (for image links)",
             folder_options,
@@ -177,7 +182,7 @@ with tab2:
         if st.button("Generate Recipes"):
             try:
                 st.info("Generating recipes...")
-                final_sheet = tag_sheet_id
+                final_sheet = recipe_sheet_id
                 final_folder = image_folder_id
                 recipes = generate_recipes(
                     final_sheet,


### PR DESCRIPTION
## Summary
- show sheet dropdown on the Generate Recipes tab
- use the newly selected sheet when generating recipes

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*