### PR TITLE
Add folder id validation and test

### DIFF
--- a/main_tagger.py
+++ b/main_tagger.py
@@ -42,6 +42,9 @@ def list_images(folder_id):
         File metadata dictionaries with ``id``, ``name`` and ``webViewLink``.
     """
 
+    if not folder_id:
+        raise ValueError("folder_id is required")
+
     query = f"'{folder_id}' in parents and mimeType contains 'image/'"
     response = drive_service.files().list(q=query, fields="files(id, name, webViewLink)").execute()
     return response.get('files', [])

--- a/tests/test_main_tagger.py
+++ b/tests/test_main_tagger.py
@@ -114,3 +114,27 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
         'prod',
         'ang',
     ]
+
+
+def test_run_tagger_empty_folder_id_errors_before_api(monkeypatch):
+    called = {}
+
+    class FakeFiles:
+        def list(self, **kwargs):
+            called['called'] = True
+            return types.SimpleNamespace(execute=lambda: {})
+
+    class FakeDrive:
+        def files(self):
+            return FakeFiles()
+
+    monkeypatch.setattr(main_tagger, 'drive_service', FakeDrive())
+
+    try:
+        main_tagger.run_tagger('sid', '', [])
+    except ValueError as e:
+        assert 'folder' in str(e).lower()
+    else:
+        raise AssertionError('ValueError not raised')
+
+    assert 'called' not in called


### PR DESCRIPTION
## Summary
- guard `list_images` against empty folder id
- add regression test for missing folder id

## Testing
- `python - <<'PY' ...` custom test harness to run all tests (passed)
