### PR TITLE
Normalize Google IDs on entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ history.
 
 ### CLI Example
 
-You can call the utility functions from the command line. For example, to tag images:
+You can call the utility functions from the command line. Both raw IDs and full Google URLs are accepted. For example, to tag images:
 
 ```bash
 python - <<'PY'

--- a/main_tagger.py
+++ b/main_tagger.py
@@ -8,6 +8,7 @@ from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.errors import HttpError
 from google.cloud import vision
 from chat_classifier import chat_classify
+from utils import parse_google_id
 
 SCOPES = [
     'https://www.googleapis.com/auth/drive.readonly',
@@ -123,6 +124,10 @@ def run_tagger(sheet_id, folder_id, expected_content=None):
         Additional content tags to classify. Defaults to ``[]`` if not provided.
     """
 
+    sheet_id = parse_google_id(sheet_id)
+    folder_id = parse_google_id(folder_id)
+    if not sheet_id or not folder_id:
+        raise ValueError("Invalid Google ID")
     expected_content = expected_content or []
 
     rows = [[
@@ -172,8 +177,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Tag images in a Drive folder and write results to a Google Sheet"
     )
-    parser.add_argument("sheet_id", help="Destination Google Sheet ID")
-    parser.add_argument("folder_id", help="Source Google Drive folder ID")
+    parser.add_argument(
+        "sheet_id",
+        help="Destination Google Sheet ID or full URL",
+    )
+    parser.add_argument(
+        "folder_id",
+        help="Source Google Drive folder ID or full URL",
+    )
     parser.add_argument(
         "-e",
         "--expected-content",

--- a/recipe_generator.py
+++ b/recipe_generator.py
@@ -6,6 +6,7 @@ import logging
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+from utils import parse_google_id
 # Configure basic logging
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
@@ -125,6 +126,12 @@ def generate_recipes(
     selected_layouts=None,
     selected_copy_formats=None,
 ):
+    sheet_id = parse_google_id(sheet_id)
+    folder_id = parse_google_id(folder_id)
+    brand_sheet_id = parse_google_id(brand_sheet_id)
+    if not sheet_id or not folder_id or not brand_sheet_id:
+        raise ValueError("Invalid Google ID")
+
     sheets_service, drive_service = get_google_service(service_account_info)
     # Load all relevant sheets
     layouts_df = read_sheet(sheets_service, LAYOUT_COPY_SHEET_ID, 'layouts')


### PR DESCRIPTION
## Summary
- parse Google IDs at the start of `run_tagger` and `generate_recipes`
- allow CLI args to be IDs or URLs
- add tests verifying Google ID parsing
- document CLI flexibility in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*