### PR TITLE
Add folder id validation

### DIFF
--- a/main_tagger.py
+++ b/main_tagger.py
@@ -42,6 +42,9 @@ def list_images(folder_id):
         File metadata dictionaries with ``id``, ``name`` and ``webViewLink``.
     """
 
+    if not folder_id:
+        raise ValueError("Missing folder ID")
+
     query = f"'{folder_id}' in parents and mimeType contains 'image/'"
     response = drive_service.files().list(q=query, fields="files(id, name, webViewLink)").execute()
     return response.get('files', [])

--- a/tests/test_main_tagger.py
+++ b/tests/test_main_tagger.py
@@ -3,6 +3,7 @@ import sys
 import types
 import builtins
 import io
+import pytest
 
 # Stub external dependencies not installed during tests
 googleapiclient_errors = types.ModuleType('googleapiclient.errors')
@@ -114,3 +115,8 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
         'prod',
         'ang',
     ]
+
+
+def test_list_images_empty_folder():
+    with pytest.raises(ValueError, match="Missing folder ID"):
+        main_tagger.list_images("")


### PR DESCRIPTION
## Summary
- validate folder_id in `main_tagger.list_images`
- test error raised when folder id is missing

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*