### PR TITLE
Allow CLI URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Streamlit app writes previously used sheet and folder names to
 menus for quick reuse. Edit or delete this file if you need to clear your
 history.
 
+The command-line utilities initially required just the raw Google IDs. They now
+share the same parsing logic as the Streamlit app so you may provide either full
+Google URLs or the bare IDs.
+
 ### CLI Example
 
 You can call the utility functions from the command line. For example, to tag images:
@@ -66,9 +70,15 @@ You can call the utility functions from the command line. For example, to tag im
 ```bash
 python - <<'PY'
 from main_tagger import run_tagger
-run_tagger('SHEET_ID', 'FOLDER_ID', ['shoes', 'accessories'])
+run_tagger(
+    'https://docs.google.com/spreadsheets/d/SHEET_ID/edit',
+    'https://drive.google.com/drive/folders/FOLDER_ID',
+    ['shoes', 'accessories']
+)
 PY
 ```
+
+IDs alone are also valid inputs.
 
 This writes tag results to the provided Google Sheet. Recipes can be generated in a similar manner using `generate_recipes` from `recipe_generator.py`.
 

--- a/main_tagger.py
+++ b/main_tagger.py
@@ -8,6 +8,7 @@ from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.errors import HttpError
 from google.cloud import vision
 from chat_classifier import chat_classify
+from utils import parse_google_id
 
 SCOPES = [
     'https://www.googleapis.com/auth/drive.readonly',
@@ -123,6 +124,8 @@ def run_tagger(sheet_id, folder_id, expected_content=None):
         Additional content tags to classify. Defaults to ``[]`` if not provided.
     """
 
+    sheet_id = parse_google_id(sheet_id)
+    folder_id = parse_google_id(folder_id)
     expected_content = expected_content or []
 
     rows = [[

--- a/tests/test_main_tagger.py
+++ b/tests/test_main_tagger.py
@@ -114,3 +114,27 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
         'prod',
         'ang',
     ]
+
+
+def test_run_tagger_parses_urls(monkeypatch):
+    captured = {}
+
+    def fake_write(sheet_id, rows):
+        captured['sheet_id'] = sheet_id
+
+    def fake_list_images(fid):
+        captured['folder_id'] = fid
+        return [{'id': '1', 'name': 'img', 'webViewLink': 'link'}]
+
+    monkeypatch.setattr(main_tagger, 'write_to_sheet', fake_write)
+    monkeypatch.setattr(main_tagger, 'list_images', fake_list_images)
+    monkeypatch.setattr(main_tagger, 'analyze_image', lambda fid: ([], []))
+    monkeypatch.setattr(main_tagger, 'chat_classify', lambda *a, **k: {})
+
+    sheet_url = 'https://docs.google.com/spreadsheets/d/SID/edit'
+    folder_url = 'https://drive.google.com/drive/folders/FID'
+
+    main_tagger.run_tagger(sheet_url, folder_url, [])
+
+    assert captured['sheet_id'] == 'SID'
+    assert captured['folder_id'] == 'FID'


### PR DESCRIPTION
## Summary
- support Google URL inputs for command-line usage
- document that IDs were originally required but URLs work now
- update README examples
- test URL parsing in `run_tagger`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*