### PR TITLE
Add Google ID parsing to utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ run_tagger('SHEET_ID', 'FOLDER_ID', ['shoes', 'accessories'])
 PY
 ```
 
-This writes tag results to the provided Google Sheet. Recipes can be generated in a similar manner using `generate_recipes` from `recipe_generator.py`.
+Both raw IDs and full Google URLs work for the sheet and folder arguments. This writes tag results to the provided Google Sheet. Recipes can be generated in a similar manner using `generate_recipes` from `recipe_generator.py`.
 
 ## Customizing the Streamlit Theme
 

--- a/main_tagger.py
+++ b/main_tagger.py
@@ -8,6 +8,7 @@ from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.errors import HttpError
 from google.cloud import vision
 from chat_classifier import chat_classify
+from utils import parse_google_id
 
 SCOPES = [
     'https://www.googleapis.com/auth/drive.readonly',
@@ -122,6 +123,11 @@ def run_tagger(sheet_id, folder_id, expected_content=None):
     expected_content : list[str] | None, optional
         Additional content tags to classify. Defaults to ``[]`` if not provided.
     """
+
+    sheet_id = parse_google_id(sheet_id)
+    folder_id = parse_google_id(folder_id)
+    if not sheet_id or not folder_id:
+        raise ValueError("Invalid Google ID")
 
     expected_content = expected_content or []
 

--- a/recipe_generator.py
+++ b/recipe_generator.py
@@ -6,6 +6,7 @@ import logging
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+from utils import parse_google_id
 # Configure basic logging
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
@@ -125,6 +126,12 @@ def generate_recipes(
     selected_layouts=None,
     selected_copy_formats=None,
 ):
+    sheet_id = parse_google_id(sheet_id)
+    folder_id = parse_google_id(folder_id)
+    brand_sheet_id = parse_google_id(brand_sheet_id)
+    if not sheet_id or not folder_id or not brand_sheet_id:
+        raise ValueError("Invalid Google ID")
+
     sheets_service, drive_service = get_google_service(service_account_info)
     # Load all relevant sheets
     layouts_df = read_sheet(sheets_service, LAYOUT_COPY_SHEET_ID, 'layouts')


### PR DESCRIPTION
## Summary
- support Google URL inputs by parsing IDs in `run_tagger` and `generate_recipes`
- update tests to verify ID parsing
- document support for full URLs in README

## Testing
- `python -m py_compile main_tagger.py recipe_generator.py tests/test_main_tagger.py tests/test_recipe_generator.py utils.py`
- `python -m pytest -q` *(fails: No module named pytest)*