### PR TITLE
Use httpx for OpenAI API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ google-auth-httplib2
 google-auth-oauthlib
 google-cloud-vision
 openai
+httpx
 streamlit-tags
 pytest


### PR DESCRIPTION
## Notes
- Added `httpx` dependency
- Rewrote `chat_classifier` to call the OpenAI API over HTTP with a bearer token
- Included helper to send a sample GPT‑4 message