### PR TITLE
Improve tagger scalability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ python -m pytest -q
 ## Required Environment Variables
 
 - `OPENAI_API_KEY` – API key for accessing OpenAI models.
+- `OPENAI_API_KEYS` – optional comma-separated keys enabling basic rotation when hitting rate limits.
 - `GOOGLE_SERVICE_ACCOUNT` – path to a Google service account JSON or the JSON string itself.
 
 ## `secrets.toml` Format
@@ -65,6 +66,10 @@ from main_tagger import run_tagger
 run_tagger('SHEET_ID', 'FOLDER_ID', ['shoes', 'accessories'])
 PY
 ```
+
+`run_tagger` now leverages asynchronous requests under the hood and processes
+multiple images concurrently. Use the `concurrency` parameter to adjust how many
+files are tagged at once if you encounter rate limiting.
 
 Provide the raw Google IDs for the sheet and folder arguments. This writes tag results to the provided Google Sheet. Recipes can be generated in a similar manner using `generate_recipes` from `recipe_generator.py`.
 

--- a/chat_classifier.py
+++ b/chat_classifier.py
@@ -1,9 +1,25 @@
 
 import os
 import json
+import asyncio
+import itertools
 import httpx
 
 API_URL = "https://api.openai.com/v1/chat/completions"
+
+# Support optional key rotation when OPENAI_API_KEYS is set to a comma-separated
+# list of keys. Falls back to the single OPENAI_API_KEY environment variable.
+_API_KEYS = [
+    k.strip()
+    for k in os.getenv("OPENAI_API_KEYS", os.getenv("OPENAI_API_KEY", "")).split(",")
+    if k.strip()
+]
+_KEYS_CYCLE = itertools.cycle(_API_KEYS) if _API_KEYS else itertools.cycle([""])
+
+
+def _next_api_key() -> str:
+    """Return the next API key in round-robin order."""
+    return next(_KEYS_CYCLE)
 
 def chat_classify(
     labels: list[str],
@@ -80,6 +96,101 @@ Return:
         print("ChatGPT classification HTTP error:", http_err)
     except Exception as e:
         print("ChatGPT classification error:", e)
+
+    return {
+        "audience": "unknown",
+        "product": "unknown",
+        "angle": "unknown",
+        "descriptors": [],
+        "match_content": "unknown",
+    }
+
+
+async def async_chat_classify(
+    labels: list[str],
+    web_labels: list[str],
+    expected_content=None,
+    *,
+    client: httpx.AsyncClient | None = None,
+    max_retries: int = 3,
+    backoff: float = 1.5,
+) -> dict:
+    """Asynchronous version of :func:`chat_classify` with basic retries."""
+
+    expected_content = expected_content or []
+    prompt = f"""
+You are an ad tagging assistant. Based on the following image data:
+
+Generic Labels:
+{', '.join(labels)}
+
+Web Entities:
+{', '.join(web_labels)}
+
+Return a JSON object with:
+- "audience": describe the most likely audience (e.g., mom, teen, athlete, grandma)
+- "product": name the product shown, and keep it specific if a brand is mentioned
+- "angle": the emotional or marketing angle (e.g., natural beauty, wellness, performance)
+- "descriptors": a short list of helpful visual or thematic descriptors (e.g., outdoors, close-up, vibrant colors)
+
+Use the following expected content tags to set ``match_content`` to the closest tag or ``unknown`` if nothing is relevant:
+{', '.join(expected_content)}
+
+Return:
+{{
+  "audience": "...",
+  "product": "...",
+  "angle": "...",
+  "descriptors": ["...", "..."],
+  "match_content": "..."
+}}
+"""
+
+    headers = {
+        "Authorization": f"Bearer {_next_api_key()}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": "gpt-4",
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful and structured tag classification assistant.",
+            },
+            {"role": "user", "content": prompt.strip()},
+        ],
+        "temperature": 0.4,
+        "response_format": {"type": "json_object"},
+    }
+
+    attempt = 0
+    while True:
+        try:
+            if client is None:
+                async with httpx.AsyncClient() as c:
+                    resp = await c.post(API_URL, headers=headers, json=payload, timeout=30)
+            else:
+                resp = await client.post(API_URL, headers=headers, json=payload, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"]
+            result = json.loads(content)
+            result.setdefault("match_content", "unknown")
+            return result
+        except httpx.HTTPStatusError as http_err:
+            status = http_err.response.status_code
+            if status in {429, 500, 502, 503, 504} and attempt < max_retries:
+                await asyncio.sleep(backoff * (2 ** attempt))
+                attempt += 1
+                continue
+            print("ChatGPT classification HTTP error:", http_err)
+        except Exception as e:  # pragma: no cover - defensive
+            if attempt < max_retries:
+                await asyncio.sleep(backoff * (2 ** attempt))
+                attempt += 1
+                continue
+            print("ChatGPT classification error:", e)
+        break
 
     return {
         "audience": "unknown",

--- a/tests/test_main_tagger.py
+++ b/tests/test_main_tagger.py
@@ -85,17 +85,17 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
     monkeypatch.setattr(main_tagger, 'write_to_sheet', fake_write)
     monkeypatch.setattr(main_tagger, 'list_images', fake_list_images)
     monkeypatch.setattr(main_tagger, 'analyze_image', lambda fid: (['label'], ['web']))
-    monkeypatch.setattr(
-        main_tagger,
-        'chat_classify',
-        lambda *a, **k: {
+
+    async def fake_chat(*a, **k):
+        return {
             'descriptors': ['desc'],
             'match_content': 'match',
             'audience': 'aud',
             'product': 'prod',
             'angle': 'ang',
-        },
-    )
+        }
+
+    monkeypatch.setattr(main_tagger, 'async_chat_classify', fake_chat)
 
     main_tagger.run_tagger(sheet_id, folder_id, ['x'])
 


### PR DESCRIPTION
## Summary
- add async classification with retry/backoff and key rotation
- process images concurrently in `run_tagger`
- update tests for async classifier
- document optional `OPENAI_API_KEYS` and async behavior

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*