### PR TITLE
Add CLI concurrency option

### DIFF
--- a/main_tagger.py
+++ b/main_tagger.py
@@ -196,6 +196,18 @@ if __name__ == "__main__":
         default=[],
         help="Additional expected content tags",
     )
+    parser.add_argument(
+        "-c",
+        "--concurrency",
+        type=int,
+        default=5,
+        help="Number of concurrent image tagging tasks",
+    )
 
     args = parser.parse_args()
-    run_tagger(args.sheet_id, args.folder_id, args.expected_content)
+    run_tagger(
+        args.sheet_id,
+        args.folder_id,
+        args.expected_content,
+        concurrency=args.concurrency,
+    )


### PR DESCRIPTION
## Summary
- allow concurrency to be set on the command line
- test that CLI forwards concurrency

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*