### PR TITLE
Add error when OpenAI API key missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ python -m pytest -q
 
 - `OPENAI_API_KEY` – API key for accessing OpenAI models.
 - `OPENAI_API_KEYS` – optional comma-separated keys enabling basic rotation when hitting rate limits.
+- Either `OPENAI_API_KEY` or `OPENAI_API_KEYS` must be set; otherwise the library raises an error when calling OpenAI services.
 - `GOOGLE_SERVICE_ACCOUNT` – path to a Google service account JSON or the JSON string itself.
 
 ## `secrets.toml` Format

--- a/chat_classifier.py
+++ b/chat_classifier.py
@@ -19,6 +19,10 @@ _KEYS_CYCLE = itertools.cycle(_API_KEYS) if _API_KEYS else itertools.cycle([""])
 
 def _next_api_key() -> str:
     """Return the next API key in round-robin order."""
+    if not _API_KEYS:
+        raise RuntimeError(
+            "No OpenAI API key provided. Set OPENAI_API_KEY or OPENAI_API_KEYS"
+        )
     return next(_KEYS_CYCLE)
 
 def chat_classify(


### PR DESCRIPTION
## Summary
- ensure `_next_api_key` errors when no OpenAI key is configured
- document that one of the `OPENAI_API_KEY(S)` env vars must be set

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*
- `python -m pytest -q` *(fails: No module named pytest)*