### PR TITLE
Improve async classifier security

### DIFF
--- a/tests/test_main_tagger.py
+++ b/tests/test_main_tagger.py
@@ -17,6 +17,8 @@ googleapiclient_http.MediaIoBaseDownload = object
 # Minimal httpx stub
 httpx_module = types.ModuleType('httpx')
 class FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
     async def __aenter__(self):
         return self
     async def __aexit__(self, exc_type, exc, tb):


### PR DESCRIPTION
## Summary
- use certifi for HTTPS verification and drop proxy env vars
- harden async_chat_classify with retries and better logging
- update httpx test stubs for new AsyncClient arguments

## Testing
- `python -m pytest -q`