### PR TITLE
Remove audience and angle from image tagger

### DIFF
--- a/main_tagger.py
+++ b/main_tagger.py
@@ -143,9 +143,7 @@ def run_tagger(sheet_id, folder_id, expected_content=None, expected_products=Non
         'Google Web Entities',
         'Descriptors',
         'Matched Content',
-        'Audience',
         'Product',
-        'Angle',
     ]]
     files = list_images(folder_id)
     for file in files:
@@ -161,9 +159,7 @@ def run_tagger(sheet_id, folder_id, expected_content=None, expected_products=Non
 
         descriptors = ', '.join(chat_result.get("descriptors", []))
         matched_content = chat_result.get("match_content", "unknown")
-        audience = chat_result.get("audience", "unknown")
         product = chat_result.get("product", "unknown")
-        angle = chat_result.get("angle", "unknown")
 
         rows.append([
             file['name'],
@@ -172,9 +168,7 @@ def run_tagger(sheet_id, folder_id, expected_content=None, expected_products=Non
             ', '.join(web_labels),
             descriptors,
             matched_content,
-            audience,
             product,
-            angle,
         ])
     write_to_sheet(sheet_id, rows)
 

--- a/tests/test_main_tagger.py
+++ b/tests/test_main_tagger.py
@@ -91,9 +91,7 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
         lambda *a, **k: {
             'descriptors': ['desc'],
             'match_content': 'match',
-            'audience': 'aud',
             'product': 'prod',
-            'angle': 'ang',
         },
     )
 
@@ -108,9 +106,7 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
         'Google Web Entities',
         'Descriptors',
         'Matched Content',
-        'Audience',
         'Product',
-        'Angle',
     ]
     assert captured['rows'][1] == [
         'img',
@@ -119,9 +115,7 @@ def test_run_tagger_outputs_basic_columns(monkeypatch):
         'web',
         'desc',
         'match',
-        'aud',
         'prod',
-        'ang',
     ]
 
 


### PR DESCRIPTION
## Summary
- stop outputting Audience and Angle columns in `run_tagger`
- update tests accordingly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e1ad889483319f2c30420eeee129